### PR TITLE
cppcheck: parsing c++ files only

### DIFF
--- a/checkall.sh
+++ b/checkall.sh
@@ -37,7 +37,7 @@ echo "Performing checkup:"
 
 # cppcheck
 cppcheck --version
-cppcheck -iclang-format-report.txt -iclang-tidy-report.txt --enable=all --library=qt.cfg --std=c++17 --language=c++ --output-file=cppcheck-report.txt ./files/*.{cpp,h,c,hpp}
+cppcheck -iclang-format-report.txt -iclang-tidy-report.txt --enable=all --library=qt.cfg --std=c++17 --language=c++ --output-file=cppcheck-report.txt ./files/*.{cpp,c}
 
 # flawfinder
 flawfinder --version

--- a/checkall.sh
+++ b/checkall.sh
@@ -37,7 +37,7 @@ echo "Performing checkup:"
 
 # cppcheck
 cppcheck --version
-cppcheck -iclang-format-report.txt -iclang-tidy-report.txt --enable=all --library=qt.cfg --std=c++17 --language=c++ --output-file=cppcheck-report.txt ./files/*.{cpp,c}
+cppcheck -iclang-format-report.txt -iclang-tidy-report.txt --enable=all --library=qt.cfg --std=c++17 --language=c++ --output-file=cppcheck-report.txt ./files/*.{cpp,c,hpp}
 
 # flawfinder
 flawfinder --version


### PR DESCRIPTION
Cppcheck doesn't work well with headers and it's making the PR comments very verbose (which is being a bit disruptive to review PRs).

We have to ensure we don't add implementation to the headers, tracked as a tech-debt item