### PR TITLE
Updating clang-format to version 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python curl clang-tidy cmake jq clang cppcheck clang-format flawfinder
+RUN apt-get -qq -y install python curl clang-tidy cmake jq clang cppcheck clang-format-12 flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/checkall.sh
+++ b/checkall.sh
@@ -44,8 +44,8 @@ flawfinder --version
 flawfinder --columns --context --singleline ./files/*.{cpp,h,c,hpp} > flawfinder-report.txt
 
 # clang-format
-clang-format --version
-./run-clang-format.py --style="{BasedOnStyle: Microsoft, UseTab: Always, ColumnLimit: 180, NamespaceIndentation: All, Language: Cpp, SortIncludes: false}" ./files/*.{cpp,h,c,hpp} > clang-format-report.txt
+clang-format-12 --version
+./run-clang-format.py --clang-format-executable="clang-format-12" --style="{BasedOnStyle: Microsoft, UseTab: Always, ColumnLimit: 180, NamespaceIndentation: All, Language: Cpp, SortIncludes: false}" ./files/*.{cpp,h,c,hpp} > clang-format-report.txt
 
 
 # We don't want very long report, let's trunk them at 500 lines max


### PR DESCRIPTION
In order to match the clang-format output of our clang power tool addon in visual, we have to use `clang-format-12` instead of `clang-format`