### PR TITLE
CT-3943: Upgrade cppcheck and install flawfinder from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 WORKDIR /build
 RUN apt-get update
 RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
-RUN pip install flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
+RUN export PYTHONPATH=${PYTHONPATH}:${HOME}/.local/lib/python3.10/site-packages
+RUN pip3 install --user flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
-RUN pip3 install --user flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /build
 RUN apt-get update
 RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
 RUN pip3 install --user flawfinder
-RUN PATH=$PATH:$HOME/.local/bin
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
+RUN apt-get -qq -y install python-is-python3 python3-pip python3-venv curl clang-tidy cmake cppcheck jq clang clang-format-12
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
+RUN pip3 install --user flawfinder
+RUN PATH=$PATH:$HOME/.local/bin
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
-RUN export PYTHONPATH=${PYTHONPATH}:${HOME}/.local/lib/python3.10/site-packages
-RUN pip3 install --user flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:latest
 
 LABEL com.github.actions.name="cpp-multicheck"
 LABEL com.github.actions.description="Check your pull request's modified files against cppcheck, clang-format and flawfinder."
@@ -10,7 +10,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 
 WORKDIR /build
 RUN apt-get update
-RUN apt-get -qq -y install python curl clang-tidy cmake jq clang cppcheck clang-format-12 flawfinder
+RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12 flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="naubryGV <73480455+naubryGV@users.noreply.github.com>"
 WORKDIR /build
 RUN apt-get update
 RUN apt-get -qq -y install python-is-python3 python3-pip curl clang-tidy cmake cppcheck jq clang clang-format-12
+RUN pip install flawfinder
 
 COPY checkall.sh /entrypoint.sh
 CMD ["bash", "/entrypoint.sh"]

--- a/checkall.sh
+++ b/checkall.sh
@@ -8,6 +8,7 @@ fi
 
 
 # Some prerequisites
+PATH=$PATH:$HOME/.local/bin
 curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
 chmod +x ./run-clang-format.py
 ERRORED=false

--- a/checkall.sh
+++ b/checkall.sh
@@ -12,6 +12,11 @@ curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-
 chmod +x ./run-clang-format.py
 ERRORED=false
 
+#setup python venv
+python3 -m venv PythonEnv
+source PythonEnv/bin/activate
+pip install flawfinder
+
 # Now let's get the modified files
 echo "Event path: $GITHUB_EVENT_PATH"
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files
@@ -133,6 +138,9 @@ then
 ERRORED=true
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
 fi
+
+#deactive python venv
+deactivate
 
 # If we have an error, we want to set an error code so the workflow is seen as failed
 if [ "$ERRORED" = true ] ; then

--- a/checkall.sh
+++ b/checkall.sh
@@ -8,7 +8,6 @@ fi
 
 
 # Some prerequisites
-PATH=$PATH:$HOME/.local/bin
 curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
 chmod +x ./run-clang-format.py
 ERRORED=false

--- a/checkall.sh
+++ b/checkall.sh
@@ -12,9 +12,6 @@ curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-
 chmod +x ./run-clang-format.py
 ERRORED=false
 
-#setup flawfinder
-pip install flawfinder
-
 # Now let's get the modified files
 echo "Event path: $GITHUB_EVENT_PATH"
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files

--- a/checkall.sh
+++ b/checkall.sh
@@ -12,8 +12,7 @@ curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-
 chmod +x ./run-clang-format.py
 ERRORED=false
 
-python venv pythonEnv
-source pythonEnv/bin/activate
+#setup python virtual env for flawfinder
 pip install flawfinder
 
 # Now let's get the modified files

--- a/checkall.sh
+++ b/checkall.sh
@@ -12,6 +12,10 @@ curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-
 chmod +x ./run-clang-format.py
 ERRORED=false
 
+python venv pythonEnv
+source pythonEnv/bin/activate
+pip install flawfinder
+
 # Now let's get the modified files
 echo "Event path: $GITHUB_EVENT_PATH"
 FILES_LINK=`jq -r '.pull_request._links.self.href' "$GITHUB_EVENT_PATH"`/files

--- a/checkall.sh
+++ b/checkall.sh
@@ -13,7 +13,6 @@ chmod +x ./run-clang-format.py
 ERRORED=false
 
 #setup flawfinder
-sudo pip install
 pip install flawfinder
 
 # Now let's get the modified files

--- a/checkall.sh
+++ b/checkall.sh
@@ -12,7 +12,8 @@ curl -JLO https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-
 chmod +x ./run-clang-format.py
 ERRORED=false
 
-#setup python virtual env for flawfinder
+#setup flawfinder
+sudo pip install
 pip install flawfinder
 
 # Now let's get the modified files


### PR DESCRIPTION
I tried getting flawfinder from pip, but I was unable to add the path to the PATH env var. From what I found online adding `PATH=$PATH:filepath` would work, but it didn't in my case. If any of you guys have an ideas pls lmk. On the bright side, flawfinder is up to date and cppcheck is version 2.7! to test use branch in CTF, I'll need to delete that branch once merged