### PR TITLE
Update checkall.sh

### DIFF
--- a/checkall.sh
+++ b/checkall.sh
@@ -95,10 +95,7 @@ OUTPUT+="$PAYLOAD_CPPCHECK"
 OUTPUT+=$'\n```\n' 
 
 PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
-if [ $CPPCHECK_LINE_NUMBER -gt 13 ]
-then
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
-fi
 
 FLAWFINDER_LINE_NUMBER=$(< flawfinder-report.txt wc -l)
 OUTPUT=$'\n\n**FLAWFINDER WARNINGS**:\n'


### PR DESCRIPTION
We don't need to restrict sending the cppcheck if less than 13 lines now I reckon